### PR TITLE
Change command format

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -7,6 +7,16 @@ import (
 	"github.com/dream11/d11-cli/internal/command"
 )
 
+// add commands to hide from help section
+var hidenCommands = []string{
+	"create test",
+	"delete test",
+	"list test",
+	"describe test",
+	"deploy test",
+	"destroy test",
+}
+
 func Cli(appName, appVersion string) *cli.CLI {
 	// initiate cli
 	// for more refer https://github.com/mitchellh/cli/blob/master/cli.go#L49
@@ -14,11 +24,11 @@ func Cli(appName, appVersion string) *cli.CLI {
 		Name: appName,
 		Version: appVersion,
 		Args: os.Args[1:],
-		Commands: command.CommandCatalog(), // TODO: Pass parsed flags here
+		Commands: command.CommandCatalog(),
 		HelpFunc: cli.BasicHelpFunc(appName),
 		Autocomplete: true,
 		HelpWriter: os.Stdout,
 		ErrorWriter: os.Stderr,
-		HiddenCommands: []string{"test"},
+		HiddenCommands: hidenCommands,
 	}
 }

--- a/internal/command/command_catalog.go
+++ b/internal/command/command_catalog.go
@@ -5,32 +5,82 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-// TODO: Accept parsed flags
+/*
+Command Structure:
+
+	d11-cli <verb> <resource> <options>
+
+Verbs are essentially the actions that will be performed,
+like: create, list, delete, etc...
+
+Verb convention:
+	- create
+	- delete
+	- describe
+	- list
+	- deploy
+	- destroy
+
+Resources are the entities on with the verbs will run,
+like: env, profile, etc...
+
+Options are merely the flags that are required with the 
+command.
+*/
 func CommandCatalog() map[string]cli.CommandFactory {
 	return map[string]cli.CommandFactory{
-		// Env Creation/Deletion
-		"env": func() (cli.Command, error) {
-			return &commands.Namespace{Create: false, Destroy: false}, nil
+		// Verbs for `env` resource
+		"list env": func() (cli.Command, error) {
+			return &commands.Env{List: true}, nil
 		},
-		"env create": func() (cli.Command, error) {
-			return &commands.Namespace{Create: true, Destroy: false}, nil
+		"describe env": func() (cli.Command, error) {
+			return &commands.Env{Describe: true}, nil
 		},
-		"env delete": func() (cli.Command, error) {
-			return &commands.Namespace{Create: false, Destroy: true}, nil
+		"deploy env": func() (cli.Command, error) {
+			return &commands.Env{Deploy: true}, nil
 		},
-		// Profile Deploy/Destroy
-		"profile": func() (cli.Command, error) {
-			return &commands.Profile{Deploy: false, Destroy: false}, nil
+		"destroy env": func() (cli.Command, error) {
+			return &commands.Env{Destroy: true}, nil
 		},
-		"profile deploy": func() (cli.Command, error) {
-			return &commands.Profile{Deploy: true, Destroy: false}, nil
+
+		// Verbs for `profile` resource
+		"create profile": func() (cli.Command, error) {
+			return &commands.Profile{Create: true}, nil
 		},
-		"profile destroy": func() (cli.Command, error) {
-			return &commands.Profile{Deploy: false, Destroy: true}, nil
+		"delete profile": func() (cli.Command, error) {
+			return &commands.Profile{Delete: true}, nil
 		},
-		// Sample command
-		"test": func() (cli.Command, error) {
-			return &commands.Test{}, nil
+		"list profile": func() (cli.Command, error) {
+			return &commands.Profile{List: true}, nil
+		},
+		"describe profile": func() (cli.Command, error) {
+			return &commands.Profile{Describe: true}, nil
+		},
+		"deploy profile": func() (cli.Command, error) {
+			return &commands.Profile{Deploy: true}, nil
+		},
+		"destroy profile": func() (cli.Command, error) {
+			return &commands.Profile{Destroy: true}, nil
+		},
+
+		// Sample commands
+		"create test": func() (cli.Command, error) {
+			return &commands.Test{Create: true}, nil
+		},
+		"delete test": func() (cli.Command, error) {
+			return &commands.Test{Delete: true}, nil
+		},
+		"list test": func() (cli.Command, error) {
+			return &commands.Test{List: true}, nil
+		},
+		"describe test": func() (cli.Command, error) {
+			return &commands.Test{Describe: true}, nil
+		},
+		"deploy test": func() (cli.Command, error) {
+			return &commands.Test{Deploy: true}, nil
+		},
+		"destroy test": func() (cli.Command, error) {
+			return &commands.Test{Destroy: true}, nil
 		},
 	}
 }

--- a/internal/command/commands/command.go
+++ b/internal/command/commands/command.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/dream11/d11-cli/d11cli"
+)
+
+// Command verbs
+type command struct {
+	Create      bool    // Create a resource record
+	Delete      bool    // Delete a resource record
+	Describe    bool    // Describe a resource
+	List        bool    // List the resources
+	Deploy      bool    // Deploy resource
+	Destroy     bool    // Destroy the deployed resource
+}
+
+func commandHelper(verb, resource string, options []string) string {
+	var opts string
+	if len(options) > 0 {
+		opts = "[Options]\n\nOptions:\n"
+	}
+
+	for _, opt := range(options) {
+		opts = opts + fmt.Sprintf("\t%s\n", opt)
+	}
+	return fmt.Sprintf("Usage: %s %s %s %s", d11cli.App.Name, verb, resource, opts)
+}
+
+func defaultHelper() string {
+	return fmt.Sprintf("Usage: %s --help", d11cli.App.Name)
+}

--- a/internal/command/commands/profile.go
+++ b/internal/command/commands/profile.go
@@ -22,315 +22,372 @@ type Chart struct {
 	Name    string    `yaml:"name"`
 }
 
-type Profile struct {
-	Deploy     bool
-	Destroy    bool
-}
+type Profile command
 
-func (n *Profile) Run(args []string) int {
-	action := "" // initiate empty action
-	if n.Deploy {
-		action = "install"
-	} else if n.Destroy {
-		action = "uninstall"
-	}
-
+func (p *Profile) Run(args []string) int {
 	// Define flagset
 	flagSet := flag.NewFlagSet("flagSet", flag.ContinueOnError)
 
 	// create flags
+	fileName := flagSet.String("file", "profile.yaml", "file name of profile yaml")
 	profileName := flagSet.String("profile", "demo", "name of profile to be used")
 	profileVersion := flagSet.String("version", "0.0.1", "version of profile to be used")
 	envName := flagSet.String("env", "demo", "name of environment to deploy the profile in")
 
-	if action == "" {
-		// positional parse flags from [2:] due to no subcommands
-		flagSet.Parse(os.Args[2:])
+	// positional parse flags from [3:]
+	flagSet.Parse(os.Args[3:])
 
-		if flagSet.NFlag() != 1 {
-			golog.Error(fmt.Errorf("`profile` requires exactly one flag `--profile=string`, %d were given.", flagSet.NFlag()))
-		}
+	if p.Create {
+		golog.Success(fmt.Sprintf("Creating profile %s@%s", *profileName, *profileVersion))
+		golog.Debug(*fileName)
+		// TODO: read profile yaml from given file and call profile create api
+		return 0
+	}
 
-		golog.Info(fmt.Sprintf("Listing all versions of %s", *envName))
+	if p.Delete {
+		golog.Success(fmt.Sprintf("Deleting profile %s@%s", *profileName, *profileVersion))
+		// TODO: take profile name and version and call profile delete api
+		return 0
+	}
+
+	if p.List {
+		golog.Success("Listing all profiles")
+		// TODO: call profiles api and display all profiles
+		return 0
+	}
+
+	if p.Describe {
+		golog.Success(fmt.Sprintf("Describing %s", *envName))
 		// TODO: call profile api and display all listed versions
 		return 0
 	}
 
-	// positional parse flags from [3:] due to subcommands
-	flagSet.Parse(os.Args[3:])
-
-	if flagSet.NFlag() != 3 {
-		golog.Error(fmt.Errorf("`profile %s` requires exactly three flags `--profile=string, --version=string, --env=string`, %d were given.", action, flagSet.NFlag()))
-	}
-
-	golog.Debug(fmt.Sprintf("%sing %s@%s in %s", action, *profileName, *profileVersion, *envName))
-
-	//-------------------------------------------------------------------------
-	// API IMPLEMENTATION
-	//-------------------------------------------------------------------------
-	golog.Println(fmt.Sprintf("Fetching profile: %s@%s", *profileName, *profileVersion))
-	// fetch profile from playground using profile name and version
-	// now unmarshal the profile into api/profile.Profile
-	profile := profile.Profile{
-		Name: "p1",
-		Version: "1.0.0",
-		Services: []profile.Service{
-			{
-				Name: "fantasy-tour",
-				Version: "1.1.1",
-			},
-		},
-	}
-	// Throw error if profile not successfuly unmarshaled
-	golog.Success(fmt.Sprintf("Profile %s@%s fetched successfully!", profile.Name, profile.Version))
-
-	// on parsing the above retreived profile
-	// we now have a list of service version
-	for _, service := range profile.Services {
-		golog.Println(fmt.Sprintf("Fetching service: %s@%s", service.Name, service.Version))
-		// now fetch service details from playground
-		// now unmarshal each service into api/service.Service
-		// Throw error if services not successfuly unmarshaled
-		golog.Success(fmt.Sprintf("Service %s@%s fetched successfully!", service.Name, service.Version))
-	}
-	
-	services := service.Services{
-		{
-			Name: "fantasy-tour",
-			Version: "1.1.1",
-			Components: []service.Component{
-				{
-					Name: "bb-rds",
-					Version: "1.1.1",
-				},
+	// initiate fetching data only when
+	// deploy or destroy of a profile has to be done
+	if p.Deploy || p.Destroy {
+		//-------------------------------------------------------------------------
+		// API IMPLEMENTATION
+		//-------------------------------------------------------------------------
+		golog.Println(fmt.Sprintf("Fetching profile: %s@%s", *profileName, *profileVersion))
+		// fetch profile from playground using profile name and version
+		// now unmarshal the profile into api/profile.Profile
+		profile := profile.Profile{
+			Name: "p1",
+			Version: "1.0.0",
+			Services: []profile.Service{
 				{
 					Name: "fantasy-tour",
 					Version: "1.1.1",
 				},
-				{
-					Name: "fantasy-tour-aerospike",
-					Version: "1.1.1",
-				},
-				{
-					Name: "fantasy-tour-admin",
-					Version: "1.1.1",
-				},
-				{
-					Name: "fantasy-tour-admin-rds",
-					Version: "1.1.1",
-				},
-				{
-					Name: "fantasy-tour-admin-redis",
-					Version: "1.1.1",
-				},
 			},
-		},
-	}
-
-	// on parsing the above retreived services
-	// we now have a list of component version
-	for _, service := range services {
-		for _, component := range service.Components {
-			golog.Println(fmt.Sprintf("Fetching component: %s@%s", component.Name, component.Version))
-			// now fetch component details from playground
-			// now unmarshal each component to api/component.Component
-			// Throw error if components not successfuly unmarshaled
-			golog.Success(fmt.Sprintf("Component %s@%s fetched successfully!", component.Name, component.Version))
 		}
-	}
-	
-	components := component.Components{
-		{
-			Name: "bb-rds",
-			Version: "1.1.1",
-			Type: "datastore",
-			Artifact: component.Artifact{
-				Url: "",
-				Version: "",
-				Type: "",
-			},
-		},
-		{
-			Name: "fantasy-tour",
-			Version: "1.1.1",
-			Type: "application",
-			Artifact: component.Artifact{
-				Url: "",
-				Version: "",
-				Type: "",
-			},
-		},
-		{
-			Name: "fantasy-tour-aerospike",
-			Version: "1.1.1",
-			Type: "datastore",
-			Artifact: component.Artifact{
-				Url: "",
-				Version: "",
-				Type: "",
-			},
-		},
-		{
-			Name: "fantasy-tour-admin",
-			Version: "1.1.1",
-			Type: "application",
-			Artifact: component.Artifact{
-				Url: "",
-				Version: "",
-				Type: "",
-			},
-		},
-		{
-			Name: "fantasy-tour-admin-rds",
-			Version: "1.1.1",
-			Type: "datastore",
-			Artifact: component.Artifact{
-				Url: "",
-				Version: "",
-				Type: "",
-			},
-		},
-		{
-			Name: "fantasy-tour-admin-redis",
-			Version: "1.1.1",
-			Type: "datastore",
-			Artifact: component.Artifact{
-				Url: "",
-				Version: "",
-				Type: "",
-			},
-		},
-	}
 
-	//-------------------------------------------------------------------------
+		// Throw error if profile not successfuly unmarshaled
+		golog.Success(fmt.Sprintf("Profile %s@%s fetched successfully!", profile.Name, profile.Version))
 
-	//-------------------------------------------------------------------------
-	// FILE GENERATION & DEPLOY
-	//-------------------------------------------------------------------------
-	workDir := d11cli.WorkDir.Location
-	// generate required files on the required path
-	/*
-	workdir
-	|__ profileName
-		|__ profileVersion
-			|__ serviceName
-				|__ serviceVersion
-					|__ componentName
-						|__ componentVersion
-							|__ (helm files)
-	*/
-	profileDir := path.Join(workDir, profile.Name, profile.Version)
-	golog.Warn(fmt.Sprintf("Generating files for %s@%s", profile.Name, profile.Version))
-	golog.Debug(fmt.Sprintf("Location: %s", profileDir))
+		// on parsing the above retreived profile
+		// we now have a list of service version
+		for _, service := range profile.Services {
+			golog.Println(fmt.Sprintf("Fetching service: %s@%s", service.Name, service.Version))
+			// now fetch service details from playground
+			// now unmarshal each service into api/service.Service
+			// Throw error if services not successfuly unmarshaled
+			golog.Success(fmt.Sprintf("Service %s@%s fetched successfully!", service.Name, service.Version))
+		}
 
-	profileExists, err := dir.Exists(profileDir)
-	if err != nil {
-		golog.Error(err)
-	}
+		services := service.Services{
+			{
+				Name: "fantasy-tour",
+				Version: "1.1.1",
+				Components: []service.Component{
+					{
+						Name: "bb-rds",
+						Version: "1.1.1",
+					},
+					{
+						Name: "fantasy-tour",
+						Version: "1.1.1",
+					},
+					{
+						Name: "fantasy-tour-aerospike",
+						Version: "1.1.1",
+					},
+					{
+						Name: "fantasy-tour-admin",
+						Version: "1.1.1",
+					},
+					{
+						Name: "fantasy-tour-admin-rds",
+						Version: "1.1.1",
+					},
+					{
+						Name: "fantasy-tour-admin-redis",
+						Version: "1.1.1",
+					},
+				},
+			},
+		}
 
-	if profileExists {
-		golog.Warn(fmt.Sprintf("Running profile %s on %s@%s", action, profile.Name, profile.Version))
+		// on parsing the above retreived services
+		// we now have a list of component version
+		for _, service := range services {
+			for _, component := range service.Components {
+				golog.Println(fmt.Sprintf("Fetching component: %s@%s", component.Name, component.Version))
+				// now fetch component details from playground
+				// now unmarshal each component to api/component.Component
+				// Throw error if components not successfuly unmarshaled
+				golog.Success(fmt.Sprintf("Component %s@%s fetched successfully!", component.Name, component.Version))
+			}
+		}
+
+		components := component.Components{
+			{
+				Name: "bb-rds",
+				Version: "1.1.1",
+				Type: "datastore",
+				Artifact: component.Artifact{
+					Url: "",
+					Version: "",
+					Type: "",
+				},
+			},
+			{
+				Name: "fantasy-tour",
+				Version: "1.1.1",
+				Type: "application",
+				Artifact: component.Artifact{
+					Url: "",
+					Version: "",
+					Type: "",
+				},
+			},
+			{
+				Name: "fantasy-tour-aerospike",
+				Version: "1.1.1",
+				Type: "datastore",
+				Artifact: component.Artifact{
+					Url: "",
+					Version: "",
+					Type: "",
+				},
+			},
+			{
+				Name: "fantasy-tour-admin",
+				Version: "1.1.1",
+				Type: "application",
+				Artifact: component.Artifact{
+					Url: "",
+					Version: "",
+					Type: "",
+				},
+			},
+			{
+				Name: "fantasy-tour-admin-rds",
+				Version: "1.1.1",
+				Type: "datastore",
+				Artifact: component.Artifact{
+					Url: "",
+					Version: "",
+					Type: "",
+				},
+			},
+			{
+				Name: "fantasy-tour-admin-redis",
+				Version: "1.1.1",
+				Type: "datastore",
+				Artifact: component.Artifact{
+					Url: "",
+					Version: "",
+					Type: "",
+				},
+			},
+		}
+
+		//-------------------------------------------------------------------------
+
+		//-------------------------------------------------------------------------
+		// FILE GENERATION & DEPLOY
+		//-------------------------------------------------------------------------
+		workDir := d11cli.WorkDir.Location
+		// generate required files on the required path
+		/*
+		workdir
+		|__ profileName
+			|__ profileVersion
+				|__ serviceName
+					|__ serviceVersion
+						|__ componentName
+							|__ componentVersion
+								|__ (helm files)
+		*/
+
+		profileDir := path.Join(workDir, profile.Name, profile.Version)
+		golog.Warn(fmt.Sprintf("Generating files for %s@%s", profile.Name, profile.Version))
 		golog.Debug(fmt.Sprintf("Location: %s", profileDir))
 
-		for _, service := range profile.Services {
-			serviceDir := path.Join(profileDir, service.Name, service.Version)
-			serviceExists, err := dir.Exists(serviceDir)
-			if err != nil {
-				golog.Error(err)
-			}
+		profileExists, err := dir.Exists(profileDir)
+		if err != nil {
+			golog.Error(err)
+		}
 
-			if serviceExists {
-				golog.Warn(fmt.Sprintf("Running profile %s on %s@%s/%s@%s", action, profile.Name, profile.Version, service.Name, service.Version))
-				serviceDetails, err := services.GetService(service.Name)
+		if profileExists {
+			// golog.Warn(fmt.Sprintf("Running profile %s on %s@%s", action, profile.Name, profile.Version))
+			golog.Debug(fmt.Sprintf("Location: %s", profileDir))
+
+			for _, service := range profile.Services {
+				serviceDir := path.Join(profileDir, service.Name, service.Version)
+				serviceExists, err := dir.Exists(serviceDir)
 				if err != nil {
 					golog.Error(err)
 				}
 
-				for _, component := range serviceDetails.Components {
-					componentDir := path.Join(serviceDir, component.Name, component.Version)
-					componentExists, err := dir.Exists(componentDir)
+				if serviceExists {
+					// golog.Warn(fmt.Sprintf("Running profile %s on %s@%s/%s@%s", action, profile.Name, profile.Version, service.Name, service.Version))
+					serviceDetails, err := services.GetService(service.Name)
 					if err != nil {
 						golog.Error(err)
 					}
 
-					if componentExists {
-						golog.Warn(fmt.Sprintf("Running profile %s on %s@%s/%s@%s/%s@%s", action, profile.Name, profile.Version, service.Name, service.Version, component.Name, component.Version))
-						componentDetails, err := components.GetComponent(component.Name)
+					for _, component := range serviceDetails.Components {
+						componentDir := path.Join(serviceDir, component.Name, component.Version)
+						componentExists, err := dir.Exists(componentDir)
 						if err != nil {
 							golog.Error(err)
 						}
 
-						chart, err := parseHelmChart(path.Join(componentDir, "Chart.yaml"))
-						if err != nil {
-							golog.Error(err)
-						}
+						if componentExists {
+							// golog.Warn(fmt.Sprintf("Running profile %s on %s@%s/%s@%s/%s@%s", action, profile.Name, profile.Version, service.Name, service.Version, component.Name, component.Version))
+							componentDetails, err := components.GetComponent(component.Name)
+							if err != nil {
+								golog.Error(err)
+							}
 
-						addRepoCommand := "helm repo add d11-helm-charts https://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@raw.githubusercontent.com/dream11/d11-helm-charts/feat/redis-operator/"
-						status := shell.Exec(addRepoCommand)
-						if status > 0 {
-							return status
-						}
+							chart, err := parseHelmChart(path.Join(componentDir, "Chart.yaml"))
+							if err != nil {
+								golog.Error(err)
+							}
 
-						repoUpdateCommand := "helm repo update"
-						status = shell.Exec(repoUpdateCommand)
-						if status > 0 {
-							return status
-						}
-						
-						var actionCommand string
-						if n.Deploy {
-							actionCommand = fmt.Sprintf("cd %s && helm upgrade --%s %s d11-helm-charts/%s -f %s -f %s -n %s", componentDir, action, componentDetails.Name, chart.Name, path.Join(componentDir, "values.yaml"), path.Join(componentDir, "values-stag.yaml"), *envName)
-						} else if n.Destroy {
-							actionCommand = fmt.Sprintf("cd %s && helm %s %s -n %s", componentDir, action, componentDetails.Name, *envName)
-						}
-						
-						status = shell.Exec(actionCommand)
-						if status > 0 {
-							return status
-						}
+							addRepoCommand := "helm repo add d11-helm-charts https://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@raw.githubusercontent.com/dream11/d11-helm-charts/feat/redis-operator/"
+							status := shell.Exec(addRepoCommand)
+							if status > 0 {
+								return status
+							}
 
-						golog.Success(fmt.Sprintf("%sed %s@%s", action, componentDetails.Name, componentDetails.Version))
-					} else {
-						golog.Error(fmt.Sprintf("Error while reading component, does not exists. %s", componentDir))
+							repoUpdateCommand := "helm repo update"
+							status = shell.Exec(repoUpdateCommand)
+							if status > 0 {
+								return status
+							}
+							
+							var actionCommand string
+							if p.Deploy {
+								actionCommand = fmt.Sprintf("cd %s && helm upgrade --install %s d11-helm-charts/%s -f %s -f %s -n %s", 
+									componentDir, 
+									componentDetails.Name, 
+									chart.Name, 
+									path.Join(componentDir, "values.yaml"), 
+									path.Join(componentDir, "values-stag.yaml"), 
+									*envName,
+								)
+
+								status = shell.Exec(actionCommand)
+								if status > 0 {
+									return status
+								}
+							} else if p.Destroy {
+								actionCommand = fmt.Sprintf("cd %s && helm uninstall %s -n %s", 
+									componentDir, 
+									componentDetails.Name, 
+									*envName,
+								)
+
+								status = shell.Exec(actionCommand)
+								if status > 0 {
+									return status
+								}
+							}
+						} else {
+							golog.Error(fmt.Sprintf("Error while reading component, does not exists. %s", componentDir))
+						}
 					}
+					
+				} else {
+					golog.Error(fmt.Sprintf("Error while reading service, does not exists. %s", serviceDir))
 				}
-				
-			} else {
-				golog.Error(fmt.Sprintf("Error while reading service, does not exists. %s", serviceDir))
 			}
+		} else {
+			golog.Error(fmt.Sprintf("Error while reading profile, does not exists. %s", profileDir))
 		}
-	} else {
-		golog.Error(fmt.Sprintf("Error while reading profile, does not exists. %s", profileDir))
+
 	}
 
-	golog.Success(fmt.Sprintf("Profile/%s@%s %sed in %s", *profileName, *profileVersion, action, *envName))
-	return 0
+	golog.Error("Not a valid command")
+
+	return 1
 }
 
-func (n *Profile) Help() string {
-	options := `
-Options:
-	--profile="name of profile"
-	--version="version of profile"
-	--env="environment name to deploy/destroy the profile"`
-
-	if n.Deploy {
-		return "Usage: d11-cli profile deploy [Options]\n" + options
-	} else if n.Destroy {
-		return "Usage: d11-cli profile destroy [Options]\n" + options
+func (p *Profile) Help() string {
+	if p.Create {
+		return commandHelper("create", "profile", []string{
+			"--profile=name of profile to create",
+			"--version=version of profile to create",
+			"--file=yaml file to read profile properties from",
+		})
+	}
+	if p.Delete {
+		return commandHelper("delete", "profile", []string{
+			"--profile=name of profile to delete",
+			"--version=version of profile to delete",
+		})
+	}
+	if p.List {
+		return commandHelper("list", "profile", []string{})
+	}
+	if p.Describe {
+		return commandHelper("describe", "profile", []string{
+			"--profile=name of profile to describe",
+			"--version=version of profile to describe",
+		})
+	}
+	if p.Deploy {
+		return commandHelper("deploy", "profile", []string{
+			"--profile=name of profile to deploy",
+			"--version=version of profile to deploy",
+			"--env=name of env to deploy the profile in",
+		})
+	}
+	if p.Destroy {
+		return commandHelper("destroy", "profile", []string{
+			"--profile=name of profile to destroy",
+			"--version=version of profile to destroy",
+			"--env=name of env to destroy the profile in",
+		})
 	}
 
-	return "Usage: d11-cli profile [Options]\n" + options
+	return defaultHelper()
 }
 
-func (n *Profile) Synopsis() string {
-	if n.Deploy {
-		return "deploy the profile"
-	} else if n.Destroy {
-		return "destroy the deployed profile"
+func (p *Profile) Synopsis() string {
+	if p.Create {
+		return "create a profile"
 	}
-	
-	return "list profile versions"
+	if p.Delete {
+		return "delete a profile"
+	}
+	if p.List {
+		return "list all active profiles"
+	}
+	if p.Describe {
+		return "describe a profile"
+	}
+	if p.Deploy {
+		return "deploy a profile"
+	}
+	if p.Destroy {
+		return "destroy a profile"
+	}
+
+	return defaultHelper()
 }
 
 

--- a/internal/command/commands/test.go
+++ b/internal/command/commands/test.go
@@ -11,7 +11,7 @@ import (
 // --------------------------------------------------------
 // Test Command
 // --------------------------------------------------------
-type Test struct {}
+type Test command
 
 // Run implements the actual functionality of the command
 // and return exit codes based on success/failure of tasks performed
@@ -25,24 +25,103 @@ func (t *Test) Run(args []string) int {
 	// Add required flags to the defined flagset
 	testFlag := flagSet.String("test-flag", "default value", "Help text")
 	// Positional parse the flags depending upon commands and sub commands
-	flagSet.Parse(os.Args[2:])
+	flagSet.Parse(os.Args[3:])
 	// use the parsed flags
 	golog.Debug(fmt.Sprintf("-test-flag=%s", *testFlag))
 
-	golog.Success("Test Run!")
-	return 0
+	if t.Create {
+		// Perform stuff for record creation of test resource
+		golog.Success(fmt.Sprintf("Test Run(create)! flag value = %s", *testFlag))
+		return 0
+	}
+	if t.Delete {
+		// Perform stuff for record deletion of test resource
+		golog.Success(fmt.Sprintf("Test Run(delete)! flag value = %s", *testFlag))
+		return 0
+	}
+	if t.List {
+		// Perform stuff to list all test resource
+		golog.Success(fmt.Sprintf("Test Run(list)! flag value = %s", *testFlag))
+		return 0
+	}
+	if t.Describe {
+		// Perform stuff to describe a test resource
+		golog.Success(fmt.Sprintf("Test Run(describe)! flag value = %s", *testFlag))
+		return 0
+	}
+	if t.Deploy {
+		// Perform stuff to deploy a test resource
+		golog.Success(fmt.Sprintf("Test Run(deploy)! flag value = %s", *testFlag))
+		return 0
+	}
+	if t.Destroy {
+		// Perform stuff to destroy a test resource
+		golog.Success(fmt.Sprintf("Test Run(destroy)! flag value = %s", *testFlag))
+		return 0
+	}
+
+	golog.Error("Not a valid command")
+
+	return 1
 }
 
 // Help should return an explanatory string, 
-// that can explain the command
+// that can explain the command's verbs
 func (t *Test) Help() string {
-	return `Usage: d11-cli test [Options]
+	if t.Create {
+		return commandHelper("create", "test", []string{
+			"--test-flag=required value",
+		})
+	}
+	if t.Delete {
+		return commandHelper("delete", "test", []string{
+			"--test-flag=required value",
+		})
+	}
+	if t.List {
+		return commandHelper("list", "test", []string{
+			"--test-flag=required value",
+		})
+	}
+	if t.Describe {
+		return commandHelper("describe", "test", []string{
+			"--test-flag=required value",
+		})
+	}
+	if t.Deploy {
+		return commandHelper("deploy", "test", []string{
+			"--test-flag=required value",
+		})
+	}
+	if t.Destroy {
+		return commandHelper("destroy", "test", []string{
+			"--test-flag=required value",
+		})
+	}
 
-Options:
-	--test-flag="string value"`
+	return defaultHelper()
 }
 
-// Synopsis should return a breif helper text for the command
+// Synopsis should return a breif helper text for the command's verbs
 func (t *Test) Synopsis() string {
-	return "command synopsis"
+	if t.Create {
+		return "create a test resource"
+	}
+	if t.Delete {
+		return "delete a test resource"
+	}
+	if t.List {
+		return "list all test resources"
+	}
+	if t.Describe {
+		return "describe a test resource"
+	}
+	if t.Deploy {
+		return "deploy a test resource"
+	}
+	if t.Destroy {
+		return "destroy a test resource"
+	}
+
+	return defaultHelper()
 }


### PR DESCRIPTION
## Summary

Earlier the commands were written as -
```
d11-cli <resource> <verb> <options>
```

Now, this is changed to -
```
d11-cli <verb> <resource> <options>
```

`Verbs` are essentially the actions that will be performed,
like: create, list, delete, etc...

Verb convention:
	- create
	- delete
	- describe
	- list
	- deploy
	- destroy

`Resources` are the entities on with the verbs will run,
like: env, profile, etc...

`Options` are merely the flags that are required with the 
command.