### PR TITLE
feat: add flag to provide cluster name

### DIFF
--- a/api/environment/env.go
+++ b/api/environment/env.go
@@ -13,6 +13,7 @@ type Env struct {
 	State        string            `yaml:"state,omitempty" json:"state,omitempty"`
 	DeletionTime string            `yaml:"autoDeletionTime,omitempty" json:"autoDeletionTime,omitempty"`
 	Account      string            `yaml:"cloudProviderAccount,omitempty" json:"cloudProviderAccount,omitempty"`
+	Cluster      string            `yaml:"cluster,omitempty" json:"cluster,omitempty"`
 	CreatedBy    string            `yaml:"createdBy,omitempty" json:"createdBy,omitempty"`
 	UpdatedBy    string            `yaml:"updatedBy,omitempty" json:"updatedBy,omitempty"`
 	CreatedAt    string            `yaml:"createdAt,omitempty" json:"createdAt,omitempty"`

--- a/internal/command/commands/env.go
+++ b/internal/command/commands/env.go
@@ -33,6 +33,7 @@ func (e *Env) Run(args []string) int {
 	service := flagSet.String("service", "", "service name to filter out describe environment")
 	component := flagSet.String("component", "", "component name to filter out describe environment")
 	providerAccount := flagSet.String("account", "", "account name to provision the environment in")
+	cluster := flagSet.String("cluster", "", "cluster name to to provision the environment in")
 	filePath := flagSet.String("file", "environment.yaml", "file to read environment config")
 	id := flagSet.Int("id", 0, "unique id of a changelog of an env")
 
@@ -51,6 +52,7 @@ func (e *Env) Run(args []string) int {
 				Purpose: *purpose,
 				EnvType: *env,
 				Account: *providerAccount,
+				Cluster: *cluster,
 			}
 
 			response, err := envClient.CreateEnv(envConfig)
@@ -212,7 +214,7 @@ func (e *Env) Run(args []string) int {
 			return 1
 		}
 
-		tableHeaders := []string{"Name", "Team", "Env Type", "State", "Account", "Deletion Time", "Purpose", "CreatedAt", "CreatedBy", "UpdatedAt", "UpdatedBy"}
+		tableHeaders := []string{"Name", "Team", "Env Type", "State", "Account", "Cluster", "Deletion Time", "Purpose", "CreatedAt", "CreatedBy", "UpdatedAt", "UpdatedBy"}
 		var tableData [][]interface{}
 
 		for _, env := range envList {
@@ -225,6 +227,7 @@ func (e *Env) Run(args []string) int {
 				env.EnvType,
 				env.State,
 				env.Account,
+				env.Cluster,
 				relativeDeletionTimestamp,
 				env.Purpose,
 				relativeCreatedAtTimestamp,
@@ -340,6 +343,7 @@ func (e *Env) Help() string {
 			"--purpose=reason to create environment",
 			"--env-type=type of environment",
 			"--account=account name to provision the environment in (optional)",
+			"--cluster=cluster name to provision the environment in (optional)",
 		})
 	}
 
@@ -356,6 +360,7 @@ func (e *Env) Help() string {
 			"--team=name of team",
 			"--env-type=env type of the environment",
 			"--account=cloud provider account name",
+			"--cluster=cluster name to provision the environment in",
 		})
 	}
 


### PR DESCRIPTION
# Odin version(1.0.1-alpha)
<!-- Make sure to update the Odin's version at ./app/app.go and add the same version above -->

## Features
- Add flag `--cluster` while creating env.
- `--cluster` will allow dev to provide cluster name.
- `--account` and `--cluster` flag are both to be used together compulsorily
