### PR TITLE
fix: error message for missing service def

### DIFF
--- a/internal/command/commands/service.go
+++ b/internal/command/commands/service.go
@@ -23,7 +23,7 @@ func (s *Service) Run(args []string) int {
 	// Define flag set
 	flagSet := flag.NewFlagSet("flagSet", flag.ContinueOnError)
 	// create flags
-	filePath := flagSet.String("file", "service.yaml", "file to read service config")
+	filePath := flagSet.String("file", "service.json", "file to read service config")
 	serviceName := flagSet.String("name", "", "name of service to be used")
 	serviceVersion := flagSet.String("version", "", "version of service to be used")
 	force := flagSet.Bool("force", false, "forcefully deploy the new version of the service")


### PR DESCRIPTION
# Odin version(1.2.0-alpha)
<!-- Make sure to update the Odin's version at ./app/app.go and add the same version above -->

## Bug Fix:
- When `--file` is missing or path is incorrect, error message now shows:
```
[ ERROR ] Unable to read from service.json
open service.json: no such file or directory
```
