### PR TITLE
fix: cgo disabled when building go binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ lint:
 build:
 	go mod download
 	mkdir -p bin/odin_darwin_amd64
-	env GOOS=darwin GOARCH=amd64 go build -o bin/odin_darwin_amd64/odin
+	env GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o bin/odin_darwin_amd64/odin
 	mkdir -p bin/odin_darwin_arm64
-	env GOOS=darwin GOARCH=arm64 go build -o bin/odin_darwin_arm64/odin
+	env GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o bin/odin_darwin_arm64/odin
 	mkdir -p bin/odin_linux_amd64
-	env GOOS=linux GOARCH=amd64 go build -o bin/odin_linux_amd64/odin
+	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bin/odin_linux_amd64/odin
 
 compressed-builds: build
 	cd bin/odin_darwin_amd64 && tar -czvf ../odin_darwin_amd64.tar.gz odin

--- a/app/app.go
+++ b/app/app.go
@@ -8,5 +8,5 @@ type application struct {
 // App (Application) interface
 var App application = application{
 	Name:    "odin",
-	Version: "1.3.3",
+	Version: "1.3.4",
 }


### PR DESCRIPTION
# Odin version(x.y.z)
<!-- Make sure to update the Odin's version at ./app/app.go and add the same version above -->

## Features
<!-- Add what this PR brings in as features -->

## Resources
<!-- Add any more resources that are required with this PR -->
